### PR TITLE
Add canonical schema and validate DPP payloads

### DIFF
--- a/api/dpp_api/main.py
+++ b/api/dpp_api/main.py
@@ -8,6 +8,9 @@ from typing import Optional
 from fastapi import FastAPI, Depends, HTTPException, Request, Header
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
+from pathlib import Path
+import json
+from jsonschema import Draft202012Validator
 
 # Auth and service utilities (your existing modules)
 from .auth import oidc_oauth2
@@ -25,6 +28,12 @@ from .models import (
 )
 
 app = FastAPI(title="DPP API", version="0.2.0")
+
+# Load canonical schema for payload validation
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "core" / "1-0-0.schema.json"
+with open(SCHEMA_PATH) as f:
+    CORE_SCHEMA = json.load(f)
+SCHEMA_VALIDATOR = Draft202012Validator(CORE_SCHEMA)
 
 
 # -----------------------------
@@ -80,6 +89,15 @@ def _parse_iso8601(value: str) -> dt.datetime:
     return dt_obj.astimezone(dt.timezone.utc)
 
 
+def _validate_payload(payload: dict) -> None:
+    """Validate DPP payload against canonical schema."""
+    errors = sorted(SCHEMA_VALIDATOR.iter_errors(payload), key=lambda e: e.path)
+    if errors:
+        err = errors[0]
+        loc = " -> ".join(str(x) for x in err.path)
+        raise HTTPException(status_code=400, detail=f"Schema validation error at {loc}: {err.message}")
+
+
 # -----------------------------
 # Endpoints
 # -----------------------------
@@ -89,6 +107,7 @@ def create_dpp(
     token=Depends(oidc_oauth2),
     db: Session = Depends(get_session),
 ):
+    _validate_payload(cmd.payload)
     # Normalize and mint identifiers
     pid = normalize_id(cmd.product_id)
     dl_uri = generate_dl(pid, cmd.model, cmd.batch)
@@ -194,6 +213,7 @@ def create_dpp_version(
         valid_from = _parse_iso8601(cmd.valid_from)
 
     # Insert new version (append-only)
+    _validate_payload(cmd.payload)
     v = DppVersion(
         dpp_id=dpp_id,
         version=next_ver,

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "pyjwt[crypto]>=2.8.0",
     "sqlalchemy>=2.0.43",
     "uvicorn>=0.35.0",
+    "jsonschema>=4.22.0",
 ]

--- a/schemas/core/1-0-0.schema.json
+++ b/schemas/core/1-0-0.schema.json
@@ -1,0 +1,97 @@
+{
+  "$id": "https://example.org/dpp/schemas/core/1-0-0.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DPP Core Envelope",
+  "type": "object",
+  "required": ["id", "schemaVersion", "dppUrl", "product", "provenance"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uri",
+      "description": "Globally unique, resolvable identifier (e.g., web-enabled ISO/IEC 15459 or IEC 61406 link)."
+    },
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "dppUrl": { "type": "string", "format": "uri" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" },
+
+    "product": {
+      "type": "object",
+      "required": ["category"],
+      "properties": {
+        "gtin": { "type": "string" },
+        "model": { "type": "string" },
+        "batchOrLot": { "type": "string" },
+        "serialNumber": { "type": "string" },
+        "description": { "type": "string" },
+        "category": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+
+    "provenance": {
+      "type": "object",
+      "required": ["operatorId"],
+      "properties": {
+        "operatorId": { "type": "string", "description": "LEI preferred where available" },
+        "facilityId": { "type": "string", "description": "GLN where available" },
+        "countryOfOrigin": { "type": "string" },
+        "manufactureDate": { "type": "string", "format": "date" }
+      },
+      "additionalProperties": false
+    },
+
+    "compliance": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scheme", "reference"],
+        "properties": {
+          "scheme": { "type": "string" },
+          "reference": { "type": "string" },
+          "validFrom": { "type": "string", "format": "date" },
+          "validTo": { "type": "string", "format": "date" }
+        },
+        "additionalProperties": false
+      }
+    },
+
+    "documents": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "url"],
+        "properties": {
+          "type": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "hash": { "type": "string" },
+          "mime": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+
+    "profiles": {
+      "type": "object",
+      "description": "Map of product-group profiles by namespace.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "_profile": {
+            "type": "object",
+            "required": ["namespace", "version"],
+            "properties": {
+              "namespace": { "type": "string" },
+              "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add core canonical DPP JSON schema
- validate incoming payloads against canonical schema
- add jsonschema dependency

## Testing
- `python -m pytest`
- `pip install jsonschema pytest` *(fails: Could not find a version that satisfies the requirement jsonschema)*

------
https://chatgpt.com/codex/tasks/task_e_68a44bec0c9c8333b5df1d30f6a95f6b