### PR TITLE
feat: track DPP URL and update timestamps

### DIFF
--- a/api/dpp_api/main.py
+++ b/api/dpp_api/main.py
@@ -116,19 +116,21 @@ def create_dpp(
     dpp = Dpp(
         dpp_id=str(uuid.uuid4()),
         product_id=pid,
-        digital_link=dl_uri,
+        dpp_url=dl_uri,
         # created_at is DB server_default NOW(); omit to let DB fill it
     )
     db.add(dpp)
     db.flush()
 
     # First version (append-only)
+    ts = _utcnow()
     v = DppVersion(
         dpp_id=dpp.dpp_id,
         version=1,
-        valid_from=_utcnow(),
+        valid_from=ts,
         payload=cmd.payload,
     )
+    dpp.updated_at = ts
     db.add(v)
     db.commit()
 
@@ -138,7 +140,7 @@ def create_dpp(
     except Exception:
         pass
 
-    return {"dpp_id": dpp.dpp_id, "digital_link": dl_uri, "version": 1}
+    return {"dpp_id": dpp.dpp_id, "dpp_url": dl_uri, "version": 1}
 
 
 @app.get("/dpp/{dpp_id}", response_model=dict)
@@ -220,6 +222,7 @@ def create_dpp_version(
         valid_from=valid_from,
         payload=cmd.payload,
     )
+    dpp.updated_at = valid_from
     db.add(v)
     db.commit()
 

--- a/api/dpp_api/models.py
+++ b/api/dpp_api/models.py
@@ -92,9 +92,15 @@ class Dpp(Base):
 
     dpp_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     product_id: Mapped[str] = mapped_column(String(255), index=True)
-    digital_link: Mapped[str] = mapped_column(String(1024), unique=True, index=True)
+    dpp_url: Mapped[str] = mapped_column(String(1024), unique=True, index=True)
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("NOW()"), index=True
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("NOW()"),
+        onupdate=text("NOW()"),
+        index=True,
     )
 
     # versions relationship; delete-orphan to keep referential integrity clean


### PR DESCRIPTION
## Summary
- store DPP URL and track updated_at on DPP headers
- update create/version endpoints to maintain timestamp and return DPP URL

## Testing
- `python -m py_compile api/dpp_api/models.py api/dpp_api/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a451e0c03483339ffa8d37159c67ea